### PR TITLE
Handle openings external windows

### DIFF
--- a/mobicomkitui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
+++ b/mobicomkitui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
@@ -923,6 +923,11 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
         }
     }
 
+    @Override
+    public void openExternalWindow() {
+
+    }
+
     public void showAudioRecordingDialog() {
 
         if (Utils.hasMarshmallow() && PermissionsUtils.checkSelfPermissionForAudioRecording(this)) {

--- a/mobicomkitui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/MobiComKitActivityInterface.java
+++ b/mobicomkitui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/MobiComKitActivityInterface.java
@@ -80,4 +80,5 @@ public interface MobiComKitActivityInterface {
 
     void sendAudioFile(String outputFIle);
 
+    void openExternalWindow();
 }

--- a/mobicomkitui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
+++ b/mobicomkitui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
@@ -1034,6 +1034,7 @@ public class DetailedConversationAdapter extends ArrayAdapter<Message> {
         try {
             final String mimeType = FileUtils.getMimeType(smListItem.getFilePaths().get(0));
             if (mimeType != null) {
+                ((MobiComKitActivityInterface) context).openExternalWindow();
                 if (mimeType.startsWith("image")) {
                     Intent intent = new Intent(context, FullScreenImageActivity.class);
                     intent.putExtra(MobiComKitConstants.MESSAGE_JSON_INTENT, GsonUtils.getJsonFromObject(smListItem, Message.class));


### PR DESCRIPTION
is needed to catch the opening external window and emit event from ApplozicActivity